### PR TITLE
Over-ride Mage_Core_Model_Config to allow mocking functionality

### DIFF
--- a/src/app/code/community/MageTest/Core/Model/Config.php
+++ b/src/app/code/community/MageTest/Core/Model/Config.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * MageTest_Core_Model_Config
+ *
+ * @uses Mage
+ * @category MageTest
+ * @package  MageTest
+ * @copyright Copyright (c) 2013 SessionDigital. (http://www.sessiondigital.com)
+ * @author Rupert Jones <rupert@sessiondigital.com>
+ * @license http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MageTest_Core_Model_Config extends Mage_Core_Model_Config
+{
+    /**
+     * Array of mock objects, indexed by model handle
+     *
+     * @var array
+     */
+    protected $_mockObject = array();
+
+    /**
+     * Set a mock object instance for the given model class
+     *
+     * @param string $modelClass
+     * @param object $mockObject
+     *
+     * @return null
+     */
+    public function setModelInstanceMock($modelClass, $mockObject)
+    {
+        $this->_mockObject[$modelClass][] = $mockObject;
+    }
+
+    /**
+     * Reset the mock stack. Only for provided model class, if supplied
+     *
+     * @param string $modelClass
+     *
+     * @return null
+     */
+    public function resetMockStack($modelClass = null)
+    {
+        if (is_null($modelClass)) {
+            $this->_mockObject = array();
+        } else {
+            unset($this->_mockObject[$modelClass]);
+        }
+    }
+
+    /**
+     * Over-ride of getModelInstance that will check if a mock object has been provided.
+     * Mock objects are returned in a queue, until the last object, which will always be returned thereafter.
+     *
+     * @param string $modelClass
+     * @param array  $constructArguments
+     *
+     * @return object
+     */
+    public function getModelInstance($modelClass = '', $constructArguments = array())
+    {
+        if (isset($this->_mockObject[$modelClass])) {
+            if (count($this->_mockObject[$modelClass]) > 1) {
+                return array_shift($this->_mockObject[$modelClass]);
+            } else {
+                return $this->_mockObject[$modelClass][0];
+            }
+        }
+        return parent::getModelInstance($modelClass, $constructArguments);
+    }
+}

--- a/src/lib/MageTest/Bootstrap.php
+++ b/src/lib/MageTest/Bootstrap.php
@@ -60,7 +60,7 @@ class MageTest_Bootstrap {
         Mage::reset();
         Mage::setRoot();
         $this->setProtectedProperty('_app', new MageTest_Core_Model_App());
-        $this->setProtectedProperty('_config', new Mage_Core_Model_Config($options));
+        $this->setProtectedProperty('_config', new MageTest_Core_Model_Config($options));
 
         if (!empty($modules)) {
             $this->getProtectedPropertyValue('_app')->initSpecified($code, $type, $options, $modules);
@@ -85,7 +85,7 @@ class MageTest_Bootstrap {
         Mage::setRoot();
         $this->setProtectedProperty('_app', new MageTest_Core_Model_App());
         $this->setProtectedProperty('_events', new Varien_Event_Collection);
-        $this->setProtectedProperty('_config', new Mage_Core_Model_Config($options));
+        $this->setProtectedProperty('_config', new MageTest_Core_Model_Config($options));
         $this->getProtectedPropertyValue('_app')->run(array(
             'scope_code' => $code,
             'scope_type' => $type,
@@ -111,13 +111,13 @@ class MageTest_Bootstrap {
             Mage::setRoot();
             $this->setProtectedProperty('_app', new MageTest_Core_Model_App());
             $this->setProtectedProperty('_events', new Varien_Event_Collection);
-            $this->setProtectedProperty('_config', new Mage_Core_Model_Config($options));
+            $this->setProtectedProperty('_config', new MageTest_Core_Model_Config($options));
 
             Varien_Profiler::start('self::app::init');
             $this->getProtectedPropertyValue('_app')->init($code, $type, $options);
             Varien_Profiler::stop('self::app::init');
             $this->getProtectedPropertyValue('_app')->loadAreaPart(
-                Mage_Core_Model_App_Area::AREA_GLOBAL, 
+                Mage_Core_Model_App_Area::AREA_GLOBAL,
                 Mage_Core_Model_App_Area::PART_EVENTS
             );
         }


### PR DESCRIPTION
This patch allows you to set mock objects for Mage::getModel() via the Config object,
so the designated model name will return your mock rather than what Magento would
normally return.

Example:

$myMock = $this->getMock('Mage_Catalog_Model_Product');
Mage::getConfig()->setModelInstanceMock('catalog/product', $myMock);

All future Mage::getModel('catalog/product') calls will return the given mock object.

If multiple mock objects are set in sequence Magento will return each mock object in order
until the last one, which will be returned repeatedly from then on.
