### PR TITLE
Add magento composer installer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "MageTest/Mage-Test",
+    "type": "magento-module",
+    "license":"OSL-3.0",
+    "description":"Lightweight module and library for testing Magento applications with PHPUnit",
+    "authors":[
+    {
+        "name":"Alistair Stead",
+        "email":"alistair@ibuildings.com"
+    }
+    ],
+    "require": {
+        "magento-hackathon/magento-composer-installer": "*"
+    }
+}


### PR DESCRIPTION
Make Mage-Test a little bit easier to use by supporting magento composer installer. The included composer.json file probably needs a little bit of tweaking to reflect the correct authors and their up to date email addresses. 
