### PR TITLE
Support mocking magento classes by alias

### DIFF
--- a/src/lib/MageTest/PHPUnit/Framework/TestCase.php
+++ b/src/lib/MageTest/PHPUnit/Framework/TestCase.php
@@ -37,4 +37,112 @@ abstract class MageTest_PHPUnit_Framework_TestCase extends PHPUnit_Framework_Tes
         $bootstrap = new MageTest_Bootstrap;
         $bootstrap->init();
     }
+
+    /**
+     * Returns a mock object for the specified model alias.
+     *
+     * @param  string  $modelAlias
+     * @param  array   $methods
+     * @param  array   $arguments
+     * @param  string  $mockClassName
+     * @param  boolean $callOriginalConstructor
+     * @param  boolean $callOriginalClone
+     * @param  boolean $callAutoload
+     * @param  boolean $cloneArguments
+     * @return PHPUnit_Framework_MockObject_MockObject
+     * @throws PHPUnit_Framework_Exception
+     */
+    public function getModelMock($modelAlias, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = TRUE, $callOriginalClone = TRUE, $callAutoload = TRUE)
+    {
+        return $this->getMock(
+            Mage::getConfig()->getModelClassName($modelAlias),
+            $methods,
+            $arguments,
+            $mockClassName,
+            $callOriginalConstructor,
+            $callOriginalClone,
+            $callAutoload
+        );
+    }
+
+    /**
+     * Returns a mock object for the specified block alias.
+     *
+     * @param  string  $blockAlias
+     * @param  array   $methods
+     * @param  array   $arguments
+     * @param  string  $mockClassName
+     * @param  boolean $callOriginalConstructor
+     * @param  boolean $callOriginalClone
+     * @param  boolean $callAutoload
+     * @param  boolean $cloneArguments
+     * @return PHPUnit_Framework_MockObject_MockObject
+     * @throws PHPUnit_Framework_Exception
+     */
+    public function getBlockMock($blockAlias, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = TRUE, $callOriginalClone = TRUE, $callAutoload = TRUE)
+    {
+        return $this->getMock(
+            Mage::getConfig()->getBlockClassName($blockAlias),
+            $methods,
+            $arguments,
+            $mockClassName,
+            $callOriginalConstructor,
+            $callOriginalClone,
+            $callAutoload
+        );
+    }
+
+    /**
+     * Returns a mock object for the specified helper alias.
+     *
+     * @param  string  $helperAlias
+     * @param  array   $methods
+     * @param  array   $arguments
+     * @param  string  $mockClassName
+     * @param  boolean $callOriginalConstructor
+     * @param  boolean $callOriginalClone
+     * @param  boolean $callAutoload
+     * @param  boolean $cloneArguments
+     * @return PHPUnit_Framework_MockObject_MockObject
+     * @throws PHPUnit_Framework_Exception
+     */
+    public function getHelperMock($helperAlias, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = TRUE, $callOriginalClone = TRUE, $callAutoload = TRUE)
+    {
+        return $this->getMock(
+            Mage::getConfig()->getHelperClassName($helperAlias),
+            $methods,
+            $arguments,
+            $mockClassName,
+            $callOriginalConstructor,
+            $callOriginalClone,
+            $callAutoload
+        );
+    }
+
+    /**
+     * Returns a mock object for the specified resource model alias.
+     *
+     * @param  string  $resourceAlias
+     * @param  array   $methods
+     * @param  array   $arguments
+     * @param  string  $mockClassName
+     * @param  boolean $callOriginalConstructor
+     * @param  boolean $callOriginalClone
+     * @param  boolean $callAutoload
+     * @param  boolean $cloneArguments
+     * @return PHPUnit_Framework_MockObject_MockObject
+     * @throws PHPUnit_Framework_Exception
+     */
+    public function getResourceModelMock($resourceAlias, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = TRUE, $callOriginalClone = TRUE, $callAutoload = TRUE)
+    {
+        return $this->getMock(
+            Mage::getConfig()->getResourceModelClassName($resourceAlias),
+            $methods,
+            $arguments,
+            $mockClassName,
+            $callOriginalConstructor,
+            $callOriginalClone,
+            $callAutoload
+        );
+    }
 }

--- a/tests/lib/MageTest/PHPUnit/Framework/TestCaseTest.php
+++ b/tests/lib/MageTest/PHPUnit/Framework/TestCaseTest.php
@@ -1,0 +1,33 @@
+<?php
+
+class MageTest_PHPUnit_Framework_TestCaseTest 
+    extends MageTest_PHPUnit_Framework_TestCase
+{
+   public function testMocksModel()
+    {
+        $this->assertInstanceOf(
+            'Mage_Sales_Model_Order', 
+            $this->getModelMock('sales/order'));
+    }
+
+    public function testMocksResourceModel()
+    {
+        $this->assertInstanceOf(
+            'Mage_Sales_Model_Resource_Order', 
+            $this->getResourceModelMock('sales/order'));
+    }
+
+    public function testMocksHelper()
+    {
+        $this->assertInstanceOf(
+            'Mage_Catalog_Helper_Image',
+            $this->getHelperMock('catalog/image'));
+    }
+
+    public function testMocksBlock()
+    {
+        $this->assertInstanceOf(
+            'Mage_Sales_Block_Order_View',
+            $this->getBlockMock('sales/order_view'));
+    }
+}


### PR DESCRIPTION
Add support for mocking magento classes using aliases. For example

$mock = $this->getModelMock('sales/order', array('getShippingMethod'));

This should be familiar for EcomDev Test users which has the same functionality, although implemented slightly differently.
