### PR TITLE
Fix magento-composer-installer incompatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "magetest/magento-phpunit-extension",
-    "type": "library",
+    "type": "magento-module",
     "license":"MIT",
     "description":"Magento PHPUnit extension, a lightweight module and library for testing Magento applications with PHPUnit",
     "keywords": ["TDD", "unit", "unit-testing", "tests", "testing"],


### PR DESCRIPTION
Fixes #12.

In my recent update, I changed 'type' in composer.json to 'library' which is incompatible with magento-composer-installer.

To install a package with magento-composer-installer the package type must be set to 'magento-module'.
