### PR TITLE
Allow events to fire during unit tests

### DIFF
--- a/src/lib/MageTest/PHPUnit/Framework/TestCase.php
+++ b/src/lib/MageTest/PHPUnit/Framework/TestCase.php
@@ -36,6 +36,10 @@ abstract class MageTest_PHPUnit_Framework_TestCase extends PHPUnit_Framework_Tes
 
         $bootstrap = new MageTest_Bootstrap;
         $bootstrap->init();
+        $bootstrap->app()->loadAreaPart(
+            Mage_Core_Model_App_Area::AREA_GLOBAL,
+            Mage_Core_Model_App_Area::PART_EVENTS
+        );
     }
 
     /**


### PR DESCRIPTION
To write tests for functionality that relies on events to get dispatched, the global events area needs to be loaded. For unit tests, only the lightweight Mage::app()->init() gets called, which doesn't load the global events area (this is done in run() though).

This is a simple patch, but could have a fairly serious impact on existing tests that rely on the current behaviour where events are not actually dispatched.
