### PR TITLE
Let events from all magento areas to fire during unit tests

### DIFF
--- a/modman
+++ b/modman
@@ -1,6 +1,5 @@
 src/app/code/community/MageTest/Core app/code/community/MageTest/Core
 src/app/etc/modules/MageTest.xml app/etc/modules/MageTest.xml
 src/lib/MageTest lib/MageTest
-src/tests/unit/app/code/core tests/unit/app/code/core
 src/tests/phpunit.xml.dist tests/phpunit.xml.dist
 src/var/connect/MageTest.xml var/connect/MageTest.xml

--- a/src/lib/MageTest/PHPUnit/Framework/TestCase.php
+++ b/src/lib/MageTest/PHPUnit/Framework/TestCase.php
@@ -32,17 +32,19 @@ abstract class MageTest_PHPUnit_Framework_TestCase extends PHPUnit_Framework_Tes
 {
     static $bootstrapped = false;
 
-    public function setUp() 
+    public function setUp()
     {
         parent::setUp();
 
         $bootstrap = new MageTest_Bootstrap();
         $bootstrap->init();
+
         if (! self::$bootstrapped) {
-            $bootstrap->app()->loadAreaPart(
+            $this->bootstrapEventAreaParts($bootstrap, array(
                 Mage_Core_Model_App_Area::AREA_GLOBAL,
-                Mage_Core_Model_App_Area::PART_EVENTS
-            );
+                Mage_Core_Model_App_Area::AREA_ADMIN,
+                Mage_Core_Model_App_Area::AREA_FRONTEND,
+                Mage_Core_Model_App_Area::AREA_ADMINHTML));
         }
     }
 
@@ -152,5 +154,24 @@ abstract class MageTest_PHPUnit_Framework_TestCase extends PHPUnit_Framework_Tes
             $callOriginalClone,
             $callAutoload
         );
+    }
+
+    /**
+     * Loads events config part for areas included in $areas
+     *
+     * @param MageTest_Bootstrap $bootstrap
+     * @param string[] $areas
+     *
+     * @return MageTest_PHPUnit_Framework_TestCase
+     */
+    protected function bootstrapEventAreaParts($bootstrap, $areas)
+    {
+        foreach ($areas as $area) {
+            $bootstrap->app()->loadAreaPart(
+                $area,
+                Mage_Core_Model_App_Area::PART_EVENTS);
+        }
+
+        return $this;
     }
 }


### PR DESCRIPTION
Previously we only loaded the 'global' event namespace which meant if you defined an event under <adminhtml> for example, it would not be loaded at bootstrap and would not fire during a testcase.

This patch ensures that when setting up a new testcase, all event areas are loaded.

I have also removed the core tests being automatically symlinked by modman/composer. They are broken for all but the most vanilla-install stores and I'm not sure if they even work under 1.8. (Actually...that's another todo :)).
