### PR TITLE
Support phpunit 4.x and fix email capturing

### DIFF
--- a/src/app/code/community/MageTest/Core/Model/Email.php
+++ b/src/app/code/community/MageTest/Core/Model/Email.php
@@ -1,0 +1,25 @@
+<?php
+
+class MageTest_Core_Model_Email extends Mage_Core_Model_Email
+{
+    public function send()
+    {
+        if (isset($_SERVER['MAGE_TEST'])) {
+            $mail = new Zend_Mail();
+
+            if (strtolower($this->getType()) == 'html') {
+                $mail->setBodyHtml($this->getBody());
+            }
+            else {
+                $mail->setBodyText($this->getBody());
+            }
+
+            $mail->setFrom($this->getFromEmail(), $this->getFromName())
+                ->addTo($this->getToEmail(), $this->getToName())
+                ->setSubject($this->getSubject());
+            Mage::app()->setResponseEmail($mail);
+        } else {
+            parent::send();
+        }
+    }
+}

--- a/src/app/code/community/MageTest/Core/etc/config.xml
+++ b/src/app/code/community/MageTest/Core/etc/config.xml
@@ -18,6 +18,7 @@
             <core>
                 <rewrite>
                     <email_template>MageTest_Core_Model_Email_Template</email_template>
+                    <email>MageTest_Core_Model_Email</email>
                 </rewrite>
             </core>
         </models>

--- a/src/lib/MageTest/PHPUnit/Framework/ControllerTestCase.php
+++ b/src/lib/MageTest/PHPUnit/Framework/ControllerTestCase.php
@@ -31,7 +31,6 @@
 abstract class MageTest_PHPUnit_Framework_ControllerTestCase
    extends Zend_Test_PHPUnit_ControllerTestCase
 {
-    
     /**
      * undocumented class variable
      *
@@ -168,6 +167,8 @@ abstract class MageTest_PHPUnit_Framework_ControllerTestCase
      */
     public function mageBootstrap()
     {
+        $_SERVER['MAGE_TEST'] = true;
+
         $bootstrap = new MageTest_Bootstrap;
         $bootstrap->init();
     }

--- a/src/lib/MageTest/PHPUnit/Framework/TestCase.php
+++ b/src/lib/MageTest/PHPUnit/Framework/TestCase.php
@@ -32,20 +32,16 @@ abstract class MageTest_PHPUnit_Framework_TestCase extends PHPUnit_Framework_Tes
 {
     static $bootstrapped = false;
 
+    /**
+     * @var MageTest_Bootstrap
+     */
+    protected $bootstrap;
+
     public function setUp()
     {
         parent::setUp();
 
-        $bootstrap = new MageTest_Bootstrap();
-        $bootstrap->init();
-
-        if (! self::$bootstrapped) {
-            $this->bootstrapEventAreaParts($bootstrap, array(
-                Mage_Core_Model_App_Area::AREA_GLOBAL,
-                Mage_Core_Model_App_Area::AREA_ADMIN,
-                Mage_Core_Model_App_Area::AREA_FRONTEND,
-                Mage_Core_Model_App_Area::AREA_ADMINHTML));
-        }
+        $this->mageBootstrap();
     }
 
     /**
@@ -154,6 +150,35 @@ abstract class MageTest_PHPUnit_Framework_TestCase extends PHPUnit_Framework_Tes
             $callOriginalClone,
             $callAutoload
         );
+    }
+
+    /**
+     * @return MageTest_Bootstrap
+     */
+    public function mageBootstrap()
+    {
+        $_SERVER['MAGE_TEST'] = true;
+
+        $this->bootstrap = new MageTest_Bootstrap();
+        $this->bootstrap->init();
+
+        if (!self::$bootstrapped) {
+            $this->bootstrapEventAreaParts($this->bootstrap, array(
+                Mage_Core_Model_App_Area::AREA_GLOBAL,
+                Mage_Core_Model_App_Area::AREA_ADMIN,
+                Mage_Core_Model_App_Area::AREA_FRONTEND,
+                Mage_Core_Model_App_Area::AREA_ADMINHTML));
+        }
+
+        return $this->bootstrap;
+    }
+
+    /**
+     * @return MageTest_Bootstrap
+     */
+    public function getBootstrap()
+    {
+        return $this->bootstrap;
     }
 
     /**

--- a/src/lib/MageTest/PHPUnit/Framework/TestListener.php
+++ b/src/lib/MageTest/PHPUnit/Framework/TestListener.php
@@ -39,7 +39,6 @@ class MageTest_PHPUnit_Framework_TestListener implements PHPUnit_Framework_TestL
      */
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        
     }
 
     /**
@@ -51,7 +50,6 @@ class MageTest_PHPUnit_Framework_TestListener implements PHPUnit_Framework_TestL
      */
     public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
     {
-        
     }
 
     /**
@@ -63,7 +61,18 @@ class MageTest_PHPUnit_Framework_TestListener implements PHPUnit_Framework_TestL
      */
     public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        
+    }
+
+    /**
+     * Risky test.
+     *
+     * @param PHPUnit_Framework_Test $test
+     * @param Exception $e
+     * @param float $time
+     * @since  Method available since Release 4.0.0
+     */
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
     }
 
     /**
@@ -76,7 +85,6 @@ class MageTest_PHPUnit_Framework_TestListener implements PHPUnit_Framework_TestL
      */
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        
     }
 
     /**
@@ -99,7 +107,6 @@ class MageTest_PHPUnit_Framework_TestListener implements PHPUnit_Framework_TestL
      */
     public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
-        
     }
 
     /**
@@ -109,7 +116,6 @@ class MageTest_PHPUnit_Framework_TestListener implements PHPUnit_Framework_TestL
      */
     public function startTest(PHPUnit_Framework_Test $test)
     {
-        
     }
 
     /**
@@ -120,6 +126,5 @@ class MageTest_PHPUnit_Framework_TestListener implements PHPUnit_Framework_TestL
      */
     public function endTest(PHPUnit_Framework_Test $test, $time)
     {
-        
     }
 }

--- a/tests/app/code/community/MageTest/Core/Model/Admin/SessionTest.php
+++ b/tests/app/code/community/MageTest/Core/Model/Admin/SessionTest.php
@@ -37,10 +37,7 @@ class SessionTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function mageAdminSessionHasBeenPatched()
+    public function testMageAdminSessionHasBeenPatched()
     {
         $this->assertInstanceOf(
             'MageTest_Core_Model_Admin_Session',
@@ -49,10 +46,7 @@ class SessionTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @test
-     */
-    public function sessionLoginDoesNotCallCoreHeaderFunction()
+    public function testSessionLoginDoesNotCallCoreHeaderFunction()
     {
         Mage::getModel('admin/session')->login('admin', 'MageTest123');
         $this->assertEmpty(headers_list());

--- a/tests/app/code/community/MageTest/Core/Model/Email/TemplateTest.php
+++ b/tests/app/code/community/MageTest/Core/Model/Email/TemplateTest.php
@@ -2,12 +2,6 @@
 
 class MageTest_Core_Model_Email_TemplateTest extends PHPUnit_Framework_TestCase
 {
-    /**
-     * Setup fixtures and dependencies
-     *
-     * @return void
-     * @author Alistair Stead
-     **/
     public function setUp()
     {
         parent::setUp();
@@ -16,28 +10,40 @@ class MageTest_Core_Model_Email_TemplateTest extends PHPUnit_Framework_TestCase
         $stub->mageBootstrap();
     }
 
-    /**
-     * Tear down fixtures and dependencies
-     *
-     * @return void
-     * @author Alistair Stead
-     **/
-    public function tearDown()
-    {
-        parent::tearDown();
-    }
-
-    /**
-     * testingEmailTemplateModelShouldBeReturned
-     * @author Alistair Stead
-     * @test
-     */
-    public function testingEmailTemplateModelShouldBeReturned()
+    public function testEmailTemplateModelShouldBeReturned()
     {
         $this->assertInstanceOf(
             'MageTest_Core_Model_Email_Template',
             Mage::getModel('core/email_template'),
             "MageTest_Core_Model_Email_Template was not returned as expected"
         );
-    } // testingEmailTemplateModelShouldBeReturned
+    }
+
+    public function testTemplateEmailsAreCaughtAndStoredInAppModelForInspection()
+    {
+        $mailer = Mage::getModel('core/email_template');
+        $message = 'Hello, world!';
+
+        $mail = $this->sendTemplateEmailMessage($mailer, $message);
+        $this->assertEquals($message, $mail->getBodyText(true));
+    }
+
+    /**
+     * @param Mage_Core_Model_Email_Template $mailer
+     * @param string $message
+     * @return Zend_Mail
+     */
+    protected function sendTemplateEmailMessage($mailer, $message)
+    {
+        $mailer->setSenderName('Mage Test')
+            ->setTemplateText($message)
+            ->setSenderEmail('baz@qux.co.uk')
+            ->setTemplateSubject('Testing 123')
+            ->setTemplateType(Mage_Core_Model_Email_Template::TYPE_TEXT)
+            ->send('foo@bar.com', 'Foo Bar', array());
+
+        $mail = Mage::app()->getResponseEmail();
+
+        return $mail;
+    }
 }

--- a/tests/app/code/community/MageTest/Core/Model/EmailTest.php
+++ b/tests/app/code/community/MageTest/Core/Model/EmailTest.php
@@ -1,0 +1,48 @@
+<?php
+
+class MageTest_Core_Model_EmailTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        // Bootstrap Mage in the same way as during testing
+        $stub = $this->getMockForAbstractClass('MageTest_PHPUnit_Framework_ControllerTestCase');
+        $stub->mageBootstrap();
+    }
+
+    public function testEmailModelShouldBeReturned()
+    {
+        $this->assertInstanceOf(
+            'MageTest_Core_Model_Email',
+            Mage::getModel('core/email'),
+            "MageTest_Core_Model_Email was not returned as expected"
+        );
+    }
+
+    public function testEmailsAreCaughtAndStoredInAppModelForInspection()
+    {
+        $mailer = Mage::getModel('core/email');
+        $message = 'Hello, world!';
+
+        $mail = $this->sendEmailMessage($mailer, $message);
+
+        $this->assertEquals($message, $mail->getBodyText(true));
+    }
+
+    /**
+     * @param Mage_Core_Model_Email $mailer
+     * @param string $message
+     * @return Zend_Mail
+     */
+    protected function sendEmailMessage($mailer, $message)
+    {
+        $mailer->setBody($message)
+                ->setType('text')
+                ->setToEmail('foo@bar.com')
+                ->setToName('Foo Bar');
+
+        $mailer->send();
+
+        return Mage::app()->getResponseEmail();
+    }
+}


### PR DESCRIPTION
- Implement required interface for PHPUnit 4.x TestListener
- Use test prefix rather than annotation for tests
- Catch email by default during testcases
- Add an extra mail model to catch emails being sent out during tests that do not use the mail template model.
- Add tests for email capture functionality
